### PR TITLE
[WIP] Replace toggleSidebar() with new SidebarUI methods

### DIFF
--- a/chrome/Echofon/content/overlay.js
+++ b/chrome/Echofon/content/overlay.js
@@ -593,7 +593,7 @@ var EchofonOverlay = {
     break;
 
       case "sidebar":
-        toggleSidebar('viewEchofonSidebar', true);
+        SidebarUI.show('viewEchofonSidebar');
     }
   },
 
@@ -626,7 +626,7 @@ var EchofonOverlay = {
     break;
 
       case "sidebar":
-        toggleSidebar('viewEchofonSidebar', false);
+        SidebarUI.toggle('viewEchofonSidebar');
     break;
     }
   },
@@ -646,7 +646,7 @@ var EchofonOverlay = {
       case "sidebar":
       var sidebarWindow = document.getElementById("sidebar").contentWindow;
       if (sidebarWindow.location.href == "chrome://echofon/content/sidebar.xul") {
-        toggleSidebar();
+        SidebarUI.hide();
       }
       break;
     }
@@ -657,7 +657,7 @@ var EchofonOverlay = {
       this.closePanel();
     }
     else {
-      toggleSidebar('viewEchofonSidebar');
+      SidebarUI.toggle('viewEchofonSidebar');
     }
   },
 
@@ -802,7 +802,7 @@ var EchofonOverlay = {
     var sidebar = document.getElementById("sidebar");
     if (sidebar && sidebar.contentWindow) {
       if (sidebar.contentWindow.location.href == "chrome://echofon/content/sidebar.xul") {
-        toggleSidebar('viewEchofonSidebar');
+        SidebarUI.toggle('viewEchofonSidebar');
       }
     }
     this.closePanel();

--- a/chrome/Echofon/content/overlay.xul
+++ b/chrome/Echofon/content/overlay.xul
@@ -31,7 +31,7 @@
                  group="sidebar"
                  sidebarurl="chrome://echofon/content/sidebar.xul"
                  sidebartitle="Echofon"
-                 oncommand="toggleSidebar('viewEchofonSidebar');" />
+                 oncommand="SidebarUI.toggle('viewEchofonSidebar');" />
   </broadcasterset>
 
 

--- a/chrome/Echofon/content/toolbar.xml
+++ b/chrome/Echofon/content/toolbar.xml
@@ -36,7 +36,7 @@
           </xul:toolbarbutton>
         </xul:hbox>
         <xul:spacer flex="1"/>
-        <xul:toolbarbutton class="echofon-tabs-closebutton tab-close-button close-icon" oncommand="toggleSidebar();" xbl:inherits="hidden=noclosebutton"/>
+        <xul:toolbarbutton class="echofon-tabs-closebutton tab-close-button close-icon" oncommand="SidebarUI.hide();" xbl:inherits="hidden=noclosebutton"/>
       </xul:toolbar>
     </content>
 


### PR DESCRIPTION
While fixing blank tweets problem, I encountered warnings about this methods being deprecated.
Is there anybody still using old versions of Firefox ?
