### PR TITLE
[WIP] Custom keys for app

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,40 +1,12 @@
 #!/bin/bash
 
-platform='unknown'
-unamestr=$(uname)
-if [[ "$unamestr" == 'Linux' ]]; then
-   platform='linux'
-elif [[ "$unamestr" == 'Darwin' ]]; then
-   platform='mac'
-fi
-
 versionNumber=$(sed -ne '/em:version/{s/.*<em:version>\(.*\)<\/em:version>.*/\1/p;q;}' install.rdf)
-
-read -p "Enter your consumer key [Echofon's one]: " consumerKey
-read -p "Enter your consumer secret [Echofon's one]: " consumerSecret
 
 rm -rf build
 mkdir -p build/src
-dirs='chrome/ components/ defaults/ modules/ platform/ chrome.manifest install.rdf'
+cp -r --parents chrome/ components/ defaults/ modules/ platform/ chrome.manifest install.rdf build/src
 
-if [[ $platform == 'mac' ]]; then
-    rsync -rR $dirs build/src
-elif [[ $platform == 'linux' ]]; then
-    cp -r --parents $dirs build/src
-fi
-
-cd build/src
-if [[ -n consumerKey && -n consumerSecret ]]; then
-    if [[ $platform == 'mac' ]]; then
-        sed -i '' "s/%CONSUMER_KEY%/$consumerKey/g" modules/TwitterClient.jsm
-        sed -i '' "s/%CONSUMER_SECRET%/$consumerSecret/g" modules/EchofonSign.jsm
-    elif [[ $platform == 'linux' ]]; then
-        sed -i "s/%CONSUMER_KEY%/$consumerKey/g" modules/TwitterClient.jsm
-        sed -i "s/%CONSUMER_SECRET%/$consumerSecret/g" modules/EchofonSign.jsm
-    fi
-fi
-
-cd chrome/Echofon
+cd build/src/chrome/Echofon
 zip -r -9 ../Echofon.jar *
 cd ..
 rm -rf Echofon

--- a/build.sh
+++ b/build.sh
@@ -1,12 +1,40 @@
 #!/bin/bash
 
+platform='unknown'
+unamestr=$(uname)
+if [[ "$unamestr" == 'Linux' ]]; then
+   platform='linux'
+elif [[ "$unamestr" == 'Darwin' ]]; then
+   platform='mac'
+fi
+
 versionNumber=$(sed -ne '/em:version/{s/.*<em:version>\(.*\)<\/em:version>.*/\1/p;q;}' install.rdf)
+
+read -p "Enter your consumer key [Echofon's one]: " consumerKey
+read -p "Enter your consumer secret [Echofon's one]: " consumerSecret
 
 rm -rf build
 mkdir -p build/src
-cp -r --parents chrome/ components/ defaults/ modules/ platform/ chrome.manifest install.rdf build/src
+dirs='chrome/ components/ defaults/ modules/ platform/ chrome.manifest install.rdf'
 
-cd build/src/chrome/Echofon
+if [[ $platform == 'mac' ]]; then
+    rsync -rR $dirs build/src
+elif [[ $platform == 'linux' ]]; then
+    cp -r --parents $dirs build/src
+fi
+
+cd build/src
+if [[ -n consumerKey && -n consumerSecret ]]; then
+    if [[ $platform == 'mac' ]]; then
+        sed -i '' "s/%CONSUMER_KEY%/$consumerKey/g" modules/TwitterClient.jsm
+        sed -i '' "s/%CONSUMER_SECRET%/$consumerSecret/g" modules/EchofonSign.jsm
+    elif [[ $platform == 'linux' ]]; then
+        sed -i "s/%CONSUMER_KEY%/$consumerKey/g" modules/TwitterClient.jsm
+        sed -i "s/%CONSUMER_SECRET%/$consumerSecret/g" modules/EchofonSign.jsm
+    fi
+fi
+
+cd chrome/Echofon
 zip -r -9 ../Echofon.jar *
 cd ..
 rm -rf Echofon

--- a/defaults/preferences/pref.js
+++ b/defaults/preferences/pref.js
@@ -17,6 +17,8 @@ pref("extensions.twitternotifier.clearDB", false);
 pref("extensions.twitternotifier.debug", false);
 pref("extensions.twitternotifier.sync", "{}");
 pref("extensions.twitternotifier.accounts", "{}");
+pref("extensions.twitternotifier.customKey", "");
+pref("extensions.twitternotifier.customSecret", "");
 pref("extensions.twitternotifier.checkFollow", 0);
 pref("extensions.twitternotifier.applicationMode", "window");
 pref("extensions.twitternotifier.splashScreen", true);

--- a/modules/EchofonSign.jsm
+++ b/modules/EchofonSign.jsm
@@ -169,8 +169,12 @@ EchofonSign.getSignatureForSyncServer = function(str)
 
 EchofonSign.OAuthSignature = function(str, secret)
 {
-  var consumerSecret = "%CONSUMER_SECRET%";
-  if(!consumerSecret) {
+  var prefs = Cc['@mozilla.org/preferences-service;1'].getService(Components.interfaces.nsIPrefService).getBranch("extensions.twitternotifier.");
+  try {
+    const customSecret = prefs.getCharPref("customSecret");
+    if(!customSecret) throw 'No custom key';
+    return b64_hmac_sha1(customSecret + "&" + secret, str);
+  } catch(e) {
     if (Cc['@naan.net/twitterfox-sign;1']) {
       var com = Cc['@naan.net/twitterfox-sign;1'].getService(Ci.nsITwitterFoxSign);
       return com.OAuthSignature(str, secret);
@@ -179,10 +183,6 @@ EchofonSign.OAuthSignature = function(str, secret)
       return OAuthSignatureByLibrary(str, secret);
     }
   }
-  
-  var signature = b64_hmac_sha1(consumerSecret + "&" + secret, str);
-
-  return signature;
 }
 
 /*

--- a/modules/EchofonSign.jsm
+++ b/modules/EchofonSign.jsm
@@ -169,11 +169,156 @@ EchofonSign.getSignatureForSyncServer = function(str)
 
 EchofonSign.OAuthSignature = function(str, secret)
 {
-  if (Cc['@naan.net/twitterfox-sign;1']) {
-    var com = Cc['@naan.net/twitterfox-sign;1'].getService(Ci.nsITwitterFoxSign);
-    return com.OAuthSignature(str, secret);
+  var consumerSecret = "%CONSUMER_SECRET%";
+  if(!consumerSecret) {
+    if (Cc['@naan.net/twitterfox-sign;1']) {
+      var com = Cc['@naan.net/twitterfox-sign;1'].getService(Ci.nsITwitterFoxSign);
+      return com.OAuthSignature(str, secret);
+    }
+    else {
+      return OAuthSignatureByLibrary(str, secret);
+    }
   }
-  else {
-    return OAuthSignatureByLibrary(str, secret);
+  
+  var signature = b64_hmac_sha1(consumerSecret + "&" + secret, str);
+
+  return signature;
+}
+
+/*
+ * A JavaScript implementation of the Secure Hash Algorithm, SHA-1, as defined
+ * in FIPS PUB 180-1
+ * Version 2.1 Copyright Paul Johnston 2000 - 2002.
+ * Other contributors: Greg Holt, Andrew Kepert, Ydnar, Lostinet
+ * Distributed under the BSD License
+ * See http://pajhome.org.uk/crypt/md5 for details.
+ */
+
+var hexcase = 0;
+
+function hex_sha1(s){return binb2hex(core_sha1(str2binb(s),s.length * chrsz));}
+function b64_sha1(s){return binb2b64(core_sha1(str2binb(s),s.length * chrsz));}
+function str_sha1(s){return binb2str(core_sha1(str2binb(s),s.length * chrsz));}
+function hex_hmac_sha1(key, data){ return binb2hex(core_hmac_sha1(key, data));}
+function b64_hmac_sha1(key, data){ return binb2b64(core_hmac_sha1(key, data));}
+function str_hmac_sha1(key, data){ return binb2str(core_hmac_sha1(key, data));}
+
+function sha1_vm_test()
+{
+  return hex_sha1("abc") == "a9993e364706816aba3e25717850c26c9cd0d89d";
+}
+
+function core_sha1(x, len)
+{
+  x[len >> 5] |= 0x80 << (24 - len % 32);
+  x[((len + 64 >> 9) << 4) + 15] = len;
+
+  var w = Array(80);
+  var a =  1732584193;
+  var b = -271733879;
+  var c = -1732584194;
+  var d =  271733878;
+  var e = -1009589776;
+
+  for(var i = 0; i < x.length; i += 16)
+  {
+    var olda = a;
+    var oldb = b;
+    var oldc = c;
+    var oldd = d;
+    var olde = e;
+
+    for(var j = 0; j < 80; j++)
+    {
+      if(j < 16) w[j] = x[i + j];
+      else w[j] = rol(w[j-3] ^ w[j-8] ^ w[j-14] ^ w[j-16], 1);
+      var t = safe_add(safe_add(rol(a, 5), sha1_ft(j, b, c, d)), 
+                       safe_add(safe_add(e, w[j]), sha1_kt(j)));
+      e = d;
+      d = c;
+      c = rol(b, 30);
+      b = a;
+      a = t;
+    }
+
+    a = safe_add(a, olda);
+    b = safe_add(b, oldb);
+    c = safe_add(c, oldc);
+    d = safe_add(d, oldd);
+    e = safe_add(e, olde);
   }
+  return Array(a, b, c, d, e);
+  
+}
+
+function sha1_ft(t, b, c, d)
+{
+  if(t < 20) return (b & c) | ((~b) & d);
+  if(t < 40) return b ^ c ^ d;
+  if(t < 60) return (b & c) | (b & d) | (c & d);
+  return b ^ c ^ d;
+}
+
+function sha1_kt(t)
+{
+  return (t < 20) ?  1518500249 : (t < 40) ?  1859775393 :
+         (t < 60) ? -1894007588 : -899497514;
+}  
+
+function core_hmac_sha1(key, data)
+{
+  var bkey = str2binb(key);
+  if(bkey.length > 16) bkey = core_sha1(bkey, key.length * chrsz);
+
+  var ipad = Array(16), opad = Array(16);
+  for(var i = 0; i < 16; i++) 
+  {
+    ipad[i] = bkey[i] ^ 0x36363636;
+    opad[i] = bkey[i] ^ 0x5C5C5C5C;
+  }
+
+  var hash = core_sha1(ipad.concat(str2binb(data)), 512 + data.length * chrsz);
+  return core_sha1(opad.concat(hash), 512 + 160);
+}
+
+function safe_add(x, y)
+{
+  var lsw = (x & 0xFFFF) + (y & 0xFFFF);
+  var msw = (x >> 16) + (y >> 16) + (lsw >> 16);
+  return (msw << 16) | (lsw & 0xFFFF);
+}
+
+function rol(num, cnt)
+{
+  return (num << cnt) | (num >>> (32 - cnt));
+}
+
+function str2binb(str)
+{
+  var bin = Array();
+  var mask = (1 << chrsz) - 1;
+  for(var i = 0; i < str.length * chrsz; i += chrsz)
+    bin[i>>5] |= (str.charCodeAt(i / chrsz) & mask) << (24 - i%32);
+  return bin;
+}
+
+function binb2str(bin)
+{
+  var str = "";
+  var mask = (1 << chrsz) - 1;
+  for(var i = 0; i < bin.length * 32; i += chrsz)
+    str += String.fromCharCode((bin[i>>5] >>> (24 - i%32)) & mask);
+  return str;
+}
+
+function binb2hex(binarray)
+{
+  var hex_tab = hexcase ? "0123456789ABCDEF" : "0123456789abcdef";
+  var str = "";
+  for(var i = 0; i < binarray.length * 4; i++)
+  {
+    str += hex_tab.charAt((binarray[i>>2] >> ((3 - i%4)*8+4)) & 0xF) +
+           hex_tab.charAt((binarray[i>>2] >> ((3 - i%4)*8  )) & 0xF);
+  }
+  return str;
 }

--- a/modules/TwitterClient.jsm
+++ b/modules/TwitterClient.jsm
@@ -5,7 +5,7 @@ const {classes:Cc, interfaces:Ci, utils:Cu} = Components;
 
 Cu.import("resource://echofon/EchofonHttpRequest.jsm");
 
-const OAUTH_CONSUMER_KEY = "yqoymTNrS9ZDGsBnlFhIuw";
+const OAUTH_CONSUMER_KEY = "%CONSUMER_KEY%" || "yqoymTNrS9ZDGsBnlFhIuw";
 const TWITTER_API_URL    = "api.twitter.com/1.1/";
 
 function convertToHexString(data)

--- a/modules/TwitterClient.jsm
+++ b/modules/TwitterClient.jsm
@@ -5,8 +5,17 @@ const {classes:Cc, interfaces:Ci, utils:Cu} = Components;
 
 Cu.import("resource://echofon/EchofonHttpRequest.jsm");
 
-const OAUTH_CONSUMER_KEY = "%CONSUMER_KEY%" || "yqoymTNrS9ZDGsBnlFhIuw";
 const TWITTER_API_URL    = "api.twitter.com/1.1/";
+
+function getOAuthConsumerKey() {
+  var prefs = Cc['@mozilla.org/preferences-service;1'].getService(Components.interfaces.nsIPrefService).getBranch("extensions.twitternotifier.");
+  const defaultKey = "yqoymTNrS9ZDGsBnlFhIuw";
+  try {
+    return prefs.getCharPref("customKey") || defaultKey;
+  } catch(e) {
+    return defaultKey;
+  }
+}
 
 function convertToHexString(data)
 {
@@ -102,7 +111,7 @@ TwitterClient.buildOAuthHeader = function (user, method, url, param)
 
   var s = convertToHexString(hash);
 
-  var oauthparam = {"oauth_consumer_key"     : OAUTH_CONSUMER_KEY,
+  var oauthparam = {"oauth_consumer_key"     : getOAuthConsumerKey(),
 		    "oauth_timestamp"        : ts,
 		    "oauth_signature_method" : "HMAC-SHA1",
 		    "oauth_nonce"            : s + Math.random(),


### PR DESCRIPTION
With all those recent breaks, I had to backport fixes and stuff into my own version of Echofon. But tired of doing this, here are changes that could be integrated into the main repo so people can change their prefs to add their own Twitter app keys (no form for the moment).

What do you think ? (maybe we can move the sign algorithm, that used to be in the binary, into a new file).

It also breaks previous authorized accounts, you have to re-auth by deleting and re-adding them.

I'll squash everything later, so please, do not merge. ;)
